### PR TITLE
Adds texture option to schema for validation

### DIFF
--- a/configurator/src/Viewer.js
+++ b/configurator/src/Viewer.js
@@ -130,7 +130,6 @@ Viewer.prototype = {
     },
 
     _getMaterialByName: function _getMaterialByName(materialName) {
-
         if (!this.materials) {
             return null;
         }
@@ -202,21 +201,13 @@ Viewer.prototype = {
             material = [material];
         }
 
-        material.forEach(
-            function(mat) {
-                this._setMaterialColor(mat, hexColor);
-            }.bind(this)
-        );
+        material.forEach(mat => {
+            this._setMaterialColor(mat, hexColor);
+        });
     },
 
-    _setMaterialColor: function(material, hexColor) {
-        var material = this.materials.reduce(function(acc, cur) {
-            if (cur.name === material) {
-                return cur;
-            }
-            return acc;
-        }, null);
-
+    _setMaterialColor: function(materialName, hexColor) {
+        var material = this._getMaterialByName(materialName);
         var linearColor = srgbToLinear(hexToRgb(hexColor));
         material.channels.AlbedoPBR.color = linearColor;
         material.channels.DiffusePBR.color = linearColor;
@@ -232,10 +223,24 @@ Viewer.prototype = {
         });
     },
 
-    setTexture: function setTexture(materialName, channels, url) {
+    setTexture: function setTexture(material, channels, url) {
+        if (!Array.isArray(material)) {
+            material = [material];
+        }
+
+        material.forEach(mat => {
+            this._setMaterialTexture(mat, channels, url);
+        });
+    },
+
+    _setMaterialTexture: function _setMaterialTexture(materialName, channels, url) {
         var material = this._getMaterialByName(materialName);
         var texturePromise = this._addTexture(url);
         texturePromise.then(textureUid => {
+            // Accept array of channel names, or a single channel name
+            if (!Array.isArray(channels)) {
+                channels = [channels];
+            }
             for (var i = 0; i < channels.length; i++) {
                 if (
                     material.channels.hasOwnProperty(channels[i]) &&

--- a/configurator/src/schema.json
+++ b/configurator/src/schema.json
@@ -19,7 +19,8 @@
                 "anyOf": [
                     { "$ref": "#/definitions/visibleOption" },
                     { "$ref": "#/definitions/colorOption" },
-                    { "$ref": "#/definitions/selectOption" }
+                    { "$ref": "#/definitions/selectOption" },
+                    { "$ref": "#/definitions/textureOption" }
                 ]
             }
         },
@@ -60,7 +61,7 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "channels", "url"]
+            "required": ["name", "url"]
         },
 
         "modelPart": {
@@ -161,6 +162,44 @@
                     "items": {
                         "anyOf": [
                             { "$ref": "#/definitions/modelPart" }
+                        ]
+                    }
+                },
+                "default": {
+                    "description": "Default value index",
+                    "type": "integer"
+                }
+            },
+            "required": ["name", "type"]
+        },
+
+        "textureOption": {
+            "$id": "#textureOption",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Human readable option name",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type of option",
+                    "type": "string",
+                    "enum": ["texture"]
+                },
+                "material": {
+                    "description": "Material name",
+                    "type": "string"
+                },
+                "channels": {
+                    "description": "Material channels",
+                    "type": "array"
+                },
+                "options": {
+                    "description": "List of predefined textures",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            { "$ref": "#/definitions/predefinedTexture" }
                         ]
                     }
                 },

--- a/configurator/src/schema.json
+++ b/configurator/src/schema.json
@@ -188,11 +188,11 @@
                 },
                 "material": {
                     "description": "Material name",
-                    "type": "string"
+                    "type": ["string", "array"]
                 },
                 "channels": {
                     "description": "Material channels",
-                    "type": "array"
+                    "type": ["string", "array"]
                 },
                 "options": {
                     "description": "List of predefined textures",


### PR DESCRIPTION
Texture option has been merged, but raises a warning because schema is missing. This PR fixes this by adding the schema for `texture` option.